### PR TITLE
Removes temporary `temp__` workaround

### DIFF
--- a/src/lib/graphql-types.loader.ts
+++ b/src/lib/graphql-types.loader.ts
@@ -17,9 +17,7 @@ export class GraphQLTypesLoader {
 
     const types = await this.getTypesFromPaths(paths);
     const flatTypes = flatten(types);
-    // Temporary workaround: https://github.com/okgrow/merge-graphql-schemas/issues/155
-    const tempType = 'type Query { temp__: Boolean }';
-    return mergeTypes([...flatTypes, tempType], { all: true });
+    return mergeTypes([...flatTypes], { all: true });
   }
 
   public async getTypesFromPaths(paths: string | string[]): Promise<string[]> {


### PR DESCRIPTION
I am encountering an error where my services are not booting up due to multiple services providing the `Query.temp__` field.

I investigated and noticed this was a workaround for a now closed issue.

I'm attempting to test this locally but I haven't been able to install my branch. Happy to verify if you can provide some assistance.

Here's the error:

```ts
GraphQLSchemaValidationError: Field "Query.temp__" can only be defined once.
    at ApolloGateway.createSchema (/.../node_modules/@apollo/gateway/dist/index.js:207:19)
    at ApolloGateway.<anonymous> (/.../node_modules/@apollo/gateway/dist/index.js:178:32)
    at Generator.next (<anonymous>)
    at fulfilled (/.../node_modules/@apollo/gateway/dist/index.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```